### PR TITLE
Reject vectors with truncated mandatory metrics

### DIFF
--- a/cvss40.js
+++ b/cvss40.js
@@ -405,6 +405,13 @@ class Vector {
             mandatoryMetricIndex++;
         }
 
+        // A vector that ends before naming all mandatory metrics never reaches the
+        // missing-metric check inside the loop, so enforce the count once the input is spent.
+        if (mandatoryMetricIndex < 11) {
+            console.error("Error: invalid vector, missing mandatory metrics");
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
`validateStringVector` only notices a missing mandatory metric when a later metric forces the scan past an empty mandatory slot.
A vector that simply ends early never reaches it, so these validate and score:

- `CVSS:4.0/AV:N` → score 0
- `CVSS:4.0/AV:N/AC:L/AT:N/PR:L/UI:N/VC:H/VI:N/VA:N/SC:H/SI:H` (no SA) → score 8.4

Section 7 of the specification makes all eleven base metrics mandatory, and the specification's proposed negative tests include 95 truncated vectors of this shape (published in FIRSTdotorg/cvss-resources reference-vectors, all marked as errors in the score files there).

One post-loop check that the mandatory count was consumed.
Verified against the cvss-resources corpus: all 25,028 negative tests now reject, and all 462,000 valid vectors across the published files score exactly as before.